### PR TITLE
Added ignore_expire in manage() to continue using expired tokens in error cases

### DIFF
--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -138,8 +138,35 @@ def test_get_refresh_failure(monkeypatch, tmpdir):
     assert tok == 'oldtok'
     logger.warn.assert_called_with('Failed to refresh access token "%s" (but it is still valid): %s', 'mytok', exc)
 
-    tokens.TOKENS = {'mytok': {'scopes': ['myscope']}}
+    tokens.TOKENS = {'mytok': {'scopes': ['myscope'], 'expires_at': 0}}
     with pytest.raises(Exception) as exc_info:
         tok = tokens.get('mytok')
     assert exc_info.value == exc
 
+def test_get_refresh_failure_ignore_expire(monkeypatch, tmpdir):
+    tokens.configure(dir=str(tmpdir), url='https://example.org')
+
+    with open(os.path.join(str(tmpdir), 'user.json'), 'w') as fd:
+        json.dump({'application_username': 'app', 'application_password': 'pass'}, fd)
+
+    with open(os.path.join(str(tmpdir), 'client.json'), 'w') as fd:
+        json.dump({'client_id': 'cid', 'client_secret': 'sec'}, fd)
+
+    exc = Exception('FAIL')
+    response = MagicMock()
+    response.raise_for_status.side_effect = exc
+    monkeypatch.setattr('requests.post', lambda url, **kwargs: response)
+    logger = MagicMock()
+    monkeypatch.setattr('tokens.logger', logger)
+    tokens.TOKENS = {'mytok': {'access_token': 'oldtok',
+                              'ignore_expire': False,
+                              'scopes': ['myscope'],
+                              # token is still valid for 10 minutes
+                              'expires_at': time.time() + (10 * 60)}}
+    tok = tokens.get('mytok')
+    assert tok == 'oldtok'
+    logger.warn.assert_called_with('Failed to refresh access token "%s" (but it is still valid): %s', 'mytok', exc)
+
+    tokens.TOKENS = {'mytok': {'access_token':'expired-token', 'ignore_expire': True, 'scopes': ['myscope'], 'expires_at': 0}}
+    tok = tokens.get('mytok')
+    assert tok == 'expired-token'

--- a/tokens/__init__.py
+++ b/tokens/__init__.py
@@ -55,7 +55,7 @@ def configure(**kwargs):
     CONFIG.update(kwargs)
 
 
-def manage(token_name, scopes, ignore_expire = False):
+def manage(token_name, scopes, ignore_expire=False):
     """ ignore_expire will enable using expired tokens in get()
         in cases where you token service does not yield a new token """
     TOKENS[token_name] = {'scopes': scopes, 'ignore_expire': ignore_expire}

--- a/tokens/__init__.py
+++ b/tokens/__init__.py
@@ -55,10 +55,10 @@ def configure(**kwargs):
     CONFIG.update(kwargs)
 
 
-def manage(token_name, scopes, ignore_expire=False):
-    """ ignore_expire will enable using expired tokens in get()
+def manage(token_name, scopes, ignore_expiration=False):
+    """ ignore_expiration will enable using expired tokens in get()
         in cases where you token service does not yield a new token """
-    TOKENS[token_name] = {'scopes': scopes, 'ignore_expire': ignore_expire}
+    TOKENS[token_name] = {'scopes': scopes, 'ignore_expiration': ignore_expiration}
     init_fixed_tokens_from_env()
 
 
@@ -132,8 +132,9 @@ def get(token_name):
             if access_token and time.time() < token['expires_at'] + EXPIRATION_TOLERANCE_SECS:
                 # apply some tolerance, still try our old token if it's still valid
                 logger.warn('Failed to refresh access token "%s" (but it is still valid): %s', token_name, e)
+            elif token.get('ignore_expiration'):
+                logger.warn('Failed to refresh access token "%s" (ignoring expiration): %s', token_name, e)
             else:
-                if not token.get('ignore_expire', False):
-                    raise
+                raise
 
     return access_token

--- a/tokens/__init__.py
+++ b/tokens/__init__.py
@@ -132,7 +132,7 @@ def get(token_name):
             if access_token and time.time() < token['expires_at'] + EXPIRATION_TOLERANCE_SECS:
                 # apply some tolerance, still try our old token if it's still valid
                 logger.warn('Failed to refresh access token "%s" (but it is still valid): %s', token_name, e)
-            elif token.get('ignore_expiration'):
+            elif access_token and token.get('ignore_expiration'):
                 logger.warn('Failed to refresh access token "%s" (ignoring expiration): %s', token_name, e)
             else:
                 raise


### PR DESCRIPTION
Use tokens beyond their expiration date.

Added expires_at to other unit test, believe otherwise it is key error exception and not request exception
