### PR TITLE
Remove setup dependency on flake8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,11 @@ setup(
     author_email='henning.jacobs@zalando.de',
     url='https://github.com/zalando-stups/python-tokens',
     license='Apache License Version 2.0',
-    setup_requires=['flake8'],
     install_requires=['requests'],
     tests_require=['pytest-cov', 'pytest', 'mock'],
+    extras_require={
+        'tests': ['flake8'],
+    },
     cmdclass={'test': PyTest},
     test_suite='tests',
     classifiers=[


### PR DESCRIPTION
- flake8 is not (and should not be) install dependency of this package
- flake8 is now kinda crapy because depends on flakes<1.1, but modern installations of  python contain preinstalled flakes 1.1. So installation of stups-tokens fails
